### PR TITLE
fix broken azure dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=['Django>=1.11'],
     extras_require={
-        'azure': ['azure-storage-blob>=1.3.1'],
+        'azure': ['azure-storage-blob==1.3.1', 'azure.common==1.1.23'],
         'boto': ['boto>=2.32.0'],
         'boto3': ['boto3>=1.4.4'],
         'dropbox': ['dropbox>=7.2.1'],


### PR DESCRIPTION
Current problem: During build of eahub.org, this error occurs:

```from azure.common import AzureMissingResourceHttpError

ModuleNotFoundError: No module named 'azure.common'```

This is a problem within django-storages: Azure.common is required, but not listed in django-storages' requirements, as documented [here](https://github.com/jschneier/django-storages/issues/787). I fixed this by adding it to the requirements.

Once I fixed this, another issue occured, as documented [here](https://github.com/jschneier/django-storages/issues/784). I fixed it by pinning the dependency to an earlier release.

Hopefully, django-storages will fix these issues and we can then fork the latest release.